### PR TITLE
Bump version to 0.2.0 and update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,55 @@
 PATH
   remote: .
   specs:
-    omniauth-microsoft_geba_auth (0.1.3)
-      omniauth-oauth2
+    omniauth-microsoft_geba_auth (0.2.0)
+      oauth2 (>= 2.0.4)
+      omniauth-oauth2 (>= 1.8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
-    hashie (5.0.0)
-    jwt (2.6.0)
+    base64 (0.3.0)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    hashie (5.1.0)
+      logger
+    json (2.18.0)
+    jwt (3.1.2)
+      base64
+    logger (1.7.0)
     multi_xml (0.6.0)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
-    omniauth (2.1.1)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
       hashie (>= 3.4.6)
+      logger
       rack (>= 2.2.3)
       rack-protection
-    omniauth-oauth2 (1.8.0)
-      oauth2 (>= 1.4, < 3)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
-    rack (3.0.6.1)
-    rack-protection (3.0.5)
-      rack
-    ruby2_keywords (0.0.5)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
-    version_gem (1.1.1)
+    rack (3.2.4)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
+    uri (1.1.1)
+    version_gem (1.1.9)
 
 PLATFORMS
   ruby
@@ -45,4 +59,4 @@ DEPENDENCIES
   omniauth-microsoft_geba_auth!
 
 BUNDLED WITH
-   1.17.3
+   2.5.23

--- a/lib/omniauth/microsoft_geba_auth/version.rb
+++ b/lib/omniauth/microsoft_geba_auth/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module MicrosoftV2Auth
-    VERSION = '0.1.4'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/omniauth/strategies/microsoft_geba_auth.rb
+++ b/lib/omniauth/strategies/microsoft_geba_auth.rb
@@ -37,7 +37,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://graph.microsoft.com/v1.0/me').parsed
+        @raw_info ||= access_token.get('https://graph.microsoft.com/v1.0/me', snaky: false).parsed
       end
 
       # def ad_memberships
@@ -52,7 +52,8 @@ module OmniAuth
         # https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$search="displayName:sg-"&$filter=startswith(displayName,'sg-masterdata')%20or%20startswith(displayName,'sg-orderentry')&$select=displayName
         @ad_memberships ||= access_token.get(
           "https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$search=\"displayName:sg-\"&$filter=startswith(displayName,'sg-masterdata')%20or%20startswith(displayName,'sg-orderentry')%20or%20startswith(displayName,'sg-codex')&$select=displayName",
-          headers: { 'ConsistencyLevel' => 'eventual' }
+          headers: { 'ConsistencyLevel' => 'eventual' },
+          snaky: false
         ).parsed
         @ad_memberships
       end

--- a/omniauth-microsoft_geba_auth.gemspec
+++ b/omniauth-microsoft_geba_auth.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "omniauth-oauth2"
+  spec.add_runtime_dependency "omniauth-oauth2", ">= 1.8.0"
+  spec.add_runtime_dependency "oauth2", ">= 2.0.4"
 end


### PR DESCRIPTION
Update the gem version to 0.2.0 and refresh dependencies in the Gemfile.lock and gemspec to ensure compatibility with newer versions. Adjust the raw_info and ad_memberships methods to include a parameter for snaky.