### PR TITLE
Update README and version for on-premises SamAccountName support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-microsoft_geba_auth (0.2.3)
+    omniauth-microsoft_geba_auth (0.3.0)
       oauth2 (>= 2.0.4)
       omniauth-oauth2 (>= 1.8.0)
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,34 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :microsoft_geba_auth, ENV['AZURE_APPLICATION_CLIENT_ID'], ENV['AZURE_APPLICATION_CLIENT_SECRET']
 end
 ```
+
+## Microsoft Graph user info
+
+The strategy requests the signed-in user's profile from Microsoft Graph using an explicit `$select`:
+
+```text
+https://graph.microsoft.com/v1.0/me?$select=businessPhones,displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,onPremisesSamAccountName,userPrincipalName,id
+```
+
+This includes `onPremisesSamAccountName`, which is exposed as:
+
+```ruby
+auth_hash.extra.raw_info['userPrincipalName']
+```
+
+The original Microsoft Entra ID/Azure `userPrincipalName` value is preserved as:
+
+```ruby
+auth_hash.extra.raw_info['azureUserPrincipalName']
+```
+
+For example, if Microsoft Graph returns:
+
+```json
+{
+  "onPremisesSamAccountName": "krei",
+  "userPrincipalName": "K.Reiter@gebatrans.com"
+}
+```
+
+then `raw_info['userPrincipalName']` will return `"krei"`, and `raw_info['azureUserPrincipalName']` will return `"K.Reiter@gebatrans.com"`.

--- a/lib/omniauth/microsoft_geba_auth/version.rb
+++ b/lib/omniauth/microsoft_geba_auth/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module MicrosoftV2Auth
-    VERSION = '0.2.2'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/omniauth/strategies/microsoft_geba_auth.rb
+++ b/lib/omniauth/strategies/microsoft_geba_auth.rb
@@ -37,7 +37,16 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://graph.microsoft.com/v1.0/me', snaky: false).parsed
+        @raw_info ||= begin
+          info = access_token.get(
+            'https://graph.microsoft.com/v1.0/me?$select=businessPhones,displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,onPremisesSamAccountName,userPrincipalName,id',
+            snaky: false
+          ).parsed
+
+          info['azureUserPrincipalName'] = info['userPrincipalName']
+          info['userPrincipalName'] = info['onPremisesSamAccountName'] if info['onPremisesSamAccountName']
+          info
+        end
       end
 
       # def ad_memberships

--- a/omniauth-microsoft_geba_auth.gemspec
+++ b/omniauth-microsoft_geba_auth.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-microsoft_geba_auth"
-  spec.version       = "0.2.3"
+  spec.version       = "0.3.0"
   spec.authors       = ["Kai-Arne Reiter"]
   spec.email         = ["k.reiter@gebatrans.com"]
   spec.summary       = %q{omniauth provider for Microsoft V2 Authentication}


### PR DESCRIPTION
Introduce support for retrieving the on-premises SamAccountName from Microsoft Graph. Update the version to 0.3.0 and enhance the README with details on the new user info retrieval process. This change improves user profile handling in the authentication strategy.